### PR TITLE
Allow Minify to accept a file path (string) argument

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "activationEvents": [
         "onCommand:es6-css-minify.loadConfig",
         "onCommand:es6-css-minify.minify",
+        "onCommand:es6-css-minify.minifyFile",
         "onCommand:es6-css-minify.minifySelection",
         "onCommand:es6-css-minify.minifyExplorer",
         "onCommand:es6-css-minify.exportConfig",
@@ -91,6 +92,10 @@
             {
                 "command": "es6-css-minify.minify",
                 "title": "Minify: Document"
+            },
+                        {
+                "command": "es6-css-minify.minifyFile",
+                "title": "Minify: File Path"
             },
             {
                 "command": "es6-css-minify.minifySelection",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -84,6 +84,13 @@ export function activate(context: vscode.ExtensionContext): void {
                minifyDocument( doc );
                
             }
+            else {
+                   
+               vscode.window.showErrorMessage( 'File URI scheme is not "file" or file path does not end in .js or .css' );
+        
+               return; 
+        
+            }
                                         
         }),
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -61,21 +61,28 @@ export function activate(context: vscode.ExtensionContext): void {
 
             const uri = vscode.Uri.parse( file_path );
             
-            if ( uri ) {
-
-               if ( uri.scheme === 'file' && ( file.path.endsWith('.js' ) || file.path.endsWith('.css') ) {
-
-                   const doc = await vscode.workspace.openTextDocument( uri );
+            if ( !uri ) {
+            
+                vscode.window.showErrorMessage( 'Invalid file path' );
+        
+                return;
                 
-                   minifyDocument(doc);
+            }
+            
+            if ( uri.scheme === 'file' && ( file.path.endsWith('.js' ) || file.path.endsWith('.css') ) {
+
+               const doc = await vscode.workspace.openTextDocument( uri );
                 
+               if ( !doc ) {
+
+                   vscode.window.showErrorMessage( 'File not found in workspace' );
+        
+                   return;
+                   
                }
                
-            }
-            else {
-            
-               vscode.window.showErrorMessage( 'Invalid file path' );
-        
+               minifyDocument( doc );
+               
             }
                                         
         }),

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -55,6 +55,25 @@ export function activate(context: vscode.ExtensionContext): void {
 
         }),
 
+        
+        // Minify file given a path ...
+        vscode.commands.registerCommand( `${EXT_ID}.minifyFile`, ( file_path: string ) => {
+
+            const uri = vscode.Uri.parse( file_path );
+            
+            if ( uri ) {
+
+               if ( uri.scheme === 'file' && ( file.path.endsWith('.js' ) || file.path.endsWith('.css') ) {
+
+                   const doc = await vscode.workspace.openTextDocument( uri );
+                
+                   minifyDocument(doc);
+                
+               }
+               
+            }
+                                        
+        }),
 
         // Minify selection.
         vscode.commands.registerCommand(`${EXT_ID}.minifySelection`, () => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -57,7 +57,7 @@ export function activate(context: vscode.ExtensionContext): void {
 
         
         // Minify file given a path ...
-        vscode.commands.registerCommand( `${EXT_ID}.minifyFile`, ( file_path: string ) => {
+        vscode.commands.registerCommand( `${EXT_ID}.minifyFile`,  async ( file_path: string ) => {
 
             const uri = vscode.Uri.parse( file_path );
             

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -72,6 +72,11 @@ export function activate(context: vscode.ExtensionContext): void {
                }
                
             }
+            else {
+            
+               vscode.window.showErrorMessage( 'Invalid file path' );
+        
+            }
                                         
         }),
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -69,7 +69,7 @@ export function activate(context: vscode.ExtensionContext): void {
                 
             }
             
-            if ( uri.scheme === 'file' && ( file.path.endsWith( '.js' ) || file.path.endsWith( '.css') ) ) {
+            if ( uri.scheme === 'file' && ( uri.path.endsWith( '.js' ) || uri.path.endsWith( '.css') ) ) {
 
                const doc = await vscode.workspace.openTextDocument( uri );
                 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -69,7 +69,7 @@ export function activate(context: vscode.ExtensionContext): void {
                 
             }
             
-            if ( uri.scheme === 'file' && ( file.path.endsWith('.js' ) || file.path.endsWith('.css') ) {
+            if ( uri.scheme === 'file' && ( file.path.endsWith( '.js' ) || file.path.endsWith( '.css') ) ) {
 
                const doc = await vscode.workspace.openTextDocument( uri );
                 


### PR DESCRIPTION
This update would allow the Minify extension (when used in Visual Studio Code) to accept a file path argument.  The file path would contain the path of the file to be minimized.  This would be extremely useful for build tasks such as those used in Visual Studio Code "tasks.json".